### PR TITLE
Fixed charAt(int) uses in LetterRack.java and LetterRackTest.java

### DIFF
--- a/src/main/java/core_entities/game_parts/LetterRack.java
+++ b/src/main/java/core_entities/game_parts/LetterRack.java
@@ -10,26 +10,24 @@ import java.io.Serializable;
 public class LetterRack implements Serializable {
 
     private final Bag BAG_REFERENCE;
-    private final Tile[] LETTERS;
-    private final int RACK_LEN; //Not final since we're opening it to expandability for custom games
+    private Tile[] letters;
+    private int rackLen; //Not final since we're opening it to expandability for custom games
 
     //Default Constructor that will be used in the program
     public LetterRack(Bag inputBag, int inputRackLen) {
-        this.RACK_LEN = inputRackLen;
+        this.rackLen = inputRackLen;
         this.BAG_REFERENCE = inputBag;
-        this.LETTERS = new Tile[this.RACK_LEN];
-        for (int index = 0; index < this.RACK_LEN; index++){
-            this.LETTERS[index] = this.BAG_REFERENCE.pop();
-        }
+        this.letters = new Tile[this.rackLen];
+        refill();
     }
 
     /**
      * refills the rack back to full.
      */
     public void refill(){
-        for(int index = 0; index < this.RACK_LEN; index++){
-            if(this.LETTERS[index] == null){
-                this.LETTERS[index] = this.BAG_REFERENCE.pop();
+        for(int index = 0; index < this.rackLen; index++){
+            if(this.letters[index] == null){
+                this.letters[index] = this.BAG_REFERENCE.pop();
             }
         }
     }
@@ -42,7 +40,7 @@ public class LetterRack implements Serializable {
         for(char characterInWord: inputWord.toCharArray()){
             int index = findTile(characterInWord);
             if(index != -1 ) {
-                this.LETTERS[index] =null;
+                this.letters[index] =null;
             }
         }
     }
@@ -54,7 +52,7 @@ public class LetterRack implements Serializable {
      */
     private int findTile(char inputChar){
         int outputTileIndex = 0;
-        for(Tile tile: this.LETTERS){
+        for(Tile tile: this.letters){
             if(tile.getLetter() == inputChar){
                 return outputTileIndex;
             }
@@ -70,7 +68,7 @@ public class LetterRack implements Serializable {
      * @return true if the rack is not full, false otherwise.
      */
     public boolean rackNotFull(){
-        for(Tile tile: this.LETTERS){
+        for(Tile tile: this.letters){
             if(tile == null){
                 return true;
             }
@@ -78,7 +76,34 @@ public class LetterRack implements Serializable {
         return false;
     }
 
-    public Tile[] getLETTERS() {
-        return this.LETTERS;
+    /**
+     * Change the length of the rack after a game is finished
+     * and a new rank length has been set.
+     * Note: this does not save the previous rack, it resets it entirely.
+     * @param newRackLen > 0
+     */
+    public void changeRackLength(int newRackLen){
+        //empty the original rack
+        emptyingTheRack();
+        this.rackLen = newRackLen;
+        this.letters = new Tile[this.rackLen];
+
+        refill();//refill the new rack
+    }
+
+    /**
+     * Self-explanatory
+     */
+    private void emptyingTheRack() {
+        for(int x = 0; x < this.rackLen; x++){
+            if (this.letters[x] != null) {
+                this.BAG_REFERENCE.add(this.letters[x]);
+                this.letters[x] = null;
+            }
+        }
+    }
+
+    public Tile[] getLetters() {
+        return this.letters;
     }
 }

--- a/src/main/java/core_entities/game_parts/LetterRack.java
+++ b/src/main/java/core_entities/game_parts/LetterRack.java
@@ -11,14 +11,14 @@ public class LetterRack implements Serializable {
 
     private final Bag BAG_REFERENCE;
     private final Tile[] LETTERS;
-    int rackLen; //Not final since we're opening it to expandability for custom games
+    private final int RACK_LEN; //Not final since we're opening it to expandability for custom games
 
     //Default Constructor that will be used in the program
     public LetterRack(Bag inputBag, int inputRackLen) {
-        this.rackLen = inputRackLen;
+        this.RACK_LEN = inputRackLen;
         this.BAG_REFERENCE = inputBag;
-        this.LETTERS = new Tile[rackLen];
-        for (int index = 0; index < rackLen; index++){
+        this.LETTERS = new Tile[this.RACK_LEN];
+        for (int index = 0; index < this.RACK_LEN; index++){
             this.LETTERS[index] = this.BAG_REFERENCE.pop();
         }
     }
@@ -27,7 +27,7 @@ public class LetterRack implements Serializable {
      * refills the rack back to full.
      */
     public void refill(){
-        for(int index = 0; index < rackLen; index++){
+        for(int index = 0; index < this.RACK_LEN; index++){
             if(this.LETTERS[index] == null){
                 this.LETTERS[index] = this.BAG_REFERENCE.pop();
             }
@@ -70,7 +70,7 @@ public class LetterRack implements Serializable {
      * @return true if the rack is not full, false otherwise.
      */
     public boolean rackNotFull(){
-        for(Tile tile: LETTERS){
+        for(Tile tile: this.LETTERS){
             if(tile == null){
                 return true;
             }
@@ -79,6 +79,6 @@ public class LetterRack implements Serializable {
     }
 
     public Tile[] getLETTERS() {
-        return LETTERS;
+        return this.LETTERS;
     }
 }

--- a/src/main/java/core_entities/game_parts/LetterRack.java
+++ b/src/main/java/core_entities/game_parts/LetterRack.java
@@ -55,7 +55,7 @@ public class LetterRack implements Serializable {
     private int findTile(char inputChar){
         int outputTileIndex = 0;
         for(Tile tile: this.LETTERS){
-            if(tile.getLetter().charAt(0) == inputChar){
+            if(tile.getLetter() == inputChar){
                 return outputTileIndex;
             }
             else{

--- a/src/test/java/core_entities/game_parts/LetterRackTest.java
+++ b/src/test/java/core_entities/game_parts/LetterRackTest.java
@@ -1,7 +1,6 @@
 package core_entities.game_parts;
 
-import CoreEntities.GameParts.Bag;
-import CoreEntities.GameParts.Tile;
+import CoreEntities.GameParts.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/core_entities/game_parts/LetterRackTest.java
+++ b/src/test/java/core_entities/game_parts/LetterRackTest.java
@@ -17,7 +17,7 @@ class LetterRackTest {
     public void init(){
         //instantiating needed objects
         letterRack = new LetterRack(new Bag(), 7);
-        tileArray = letterRack.getLETTERS();
+        tileArray = letterRack.getLetters();
         rand = new Random();
         rand.setSeed(0);
     }
@@ -30,14 +30,14 @@ class LetterRackTest {
         //admittedly weird string conversion
         String toRemove = "" + tileArray[removedIndex].getLetter();
         letterRack.removeLetters(toRemove);
-        Assertions.assertNull(letterRack.getLETTERS()[removedIndex]);
+        Assertions.assertNull(letterRack.getLetters()[removedIndex]);
 
         //Testing rackIsNotFull
         Assertions.assertTrue(letterRack.rackNotFull());
 
         //Testing refill
         letterRack.refill();
-        for(Tile tile: letterRack.getLETTERS()){
+        for(Tile tile: letterRack.getLetters()){
             Assertions.assertNotNull(tile);
         }
 
@@ -52,9 +52,16 @@ class LetterRackTest {
         letterRack.refill();
 
         int index = 0;
-        for (Tile eachTile: letterRack.getLETTERS()){
+        for (Tile eachTile: letterRack.getLetters()){
             Assertions.assertEquals(tileArray[index].getLetter(), eachTile.getLetter());
             index++;
         }
+    }
+
+    @Test
+    public void changeRackLength(){
+        int newLength = letterRack.getLetters().length + 2;
+        letterRack.changeRackLength(newLength);
+        Assertions.assertEquals(newLength, letterRack.getLetters().length);
     }
 }

--- a/src/test/java/core_entities/game_parts/LetterRackTest.java
+++ b/src/test/java/core_entities/game_parts/LetterRackTest.java
@@ -54,7 +54,7 @@ class LetterRackTest {
 
         int index = 0;
         for (Tile eachTile: letterRack.getLETTERS()){
-            Assertions.assertEquals(tileArray[index].getLetter().charAt(0), eachTile.getLetter().charAt(0));
+            Assertions.assertEquals(tileArray[index].getLetter(), eachTile.getLetter());
             index++;
         }
     }


### PR DESCRIPTION
Removed the charAt(int) calls in LetterRack.java and LetterRackTest.java since we've switched to chars in tiles rather than strings.